### PR TITLE
Feat: Fix exec terminal not reopening after execution in mac

### DIFF
--- a/lib/focus-application.js
+++ b/lib/focus-application.js
@@ -20,15 +20,6 @@ const appleScriptMax = (windowName) => `
 tell application "${windowName}" to activate
 `;
 
-const appleScriptMinMax = (windowName, booleanString) => `
-tell application "${windowName}"
-    set windowList to every window
-    repeat with aWindow in windowList
-        set miniaturized of aWindow to ${booleanString}
-    end repeat
-end tell
-`;
-
 const runPwsh = (appName, method) => {
   let script = `powershell -ExecutionPolicy Bypass -Command "& { ${scriptPath} '${appName}' '${method}' }"`;
   return execSync(script, { shell: "powershell" });

--- a/lib/focus-application.js
+++ b/lib/focus-application.js
@@ -10,14 +10,10 @@ tell application "System Events" to tell process "${windowName}"
     set frontmost to true
 end tell`;
 
-const appleScriptMin = (windowName) => `
+const appleScriptMinMax = (windowName, state) => `
 tell application "System Events" 
-    set value of attribute "AXMinimized" of every window of application process "${windowName}" to true
+    set value of attribute "AXMinimized" of every window of application process "${windowName}" to ${state}
 end tell
-`;
-
-const appleScriptMax = (windowName) => `
-tell application "${windowName}" to activate
 `;
 
 const runPwsh = (appName, method) => {
@@ -46,7 +42,7 @@ async function hideTerminal(appName) {
 
   try {
     if (platform() == "mac") {
-      return await execSync(`osascript -e '${appleScriptMin(appName)}'`);
+      return await execSync(`osascript -e '${appleScriptMinMax(appName, true)}'`);
     } else if (platform() == "linux") {
     } else if (platform() == "windows") {
       return runPwsh(appName, "Minimize");
@@ -61,7 +57,7 @@ async function showTerminal(appName) {
   try {
 
     if (platform() == "mac") {
-      return await execSync(`osascript -e '${appleScriptMax(appName)}'`);
+      return await execSync(`osascript -e '${appleScriptMinMax(appName, false)}'`);
     } else if (platform() == "linux") {
     } else if (platform() == "windows") {
       return runPwsh(appName, "Restore");

--- a/lib/focus-application.js
+++ b/lib/focus-application.js
@@ -10,6 +10,16 @@ tell application "System Events" to tell process "${windowName}"
     set frontmost to true
 end tell`;
 
+const appleScriptMin = (windowName) => `
+tell application "System Events" 
+    set value of attribute "AXMinimized" of every window of application process "${windowName}" to true
+end tell
+`;
+
+const appleScriptMax = (windowName) => `
+tell application "${windowName}" to activate
+`;
+
 const appleScriptMinMax = (windowName, booleanString) => `
 tell application "${windowName}"
     set windowList to every window
@@ -42,10 +52,10 @@ async function focusApplication(appName) {
 }
 
 async function hideTerminal(appName) {
- 
+
   try {
     if (platform() == "mac") {
-      return await execSync(`osascript -e '${appleScriptMinMax(appName, 'true')}'`);
+      return await execSync(`osascript -e '${appleScriptMin(appName)}'`);
     } else if (platform() == "linux") {
     } else if (platform() == "windows") {
       return runPwsh(appName, "Minimize");
@@ -60,7 +70,7 @@ async function showTerminal(appName) {
   try {
 
     if (platform() == "mac") {
-      return await execSync(`osascript -e '${appleScriptMinMax(appName, 'false')}'`);
+      return await execSync(`osascript -e '${appleScriptMax(appName)}'`);
     } else if (platform() == "linux") {
     } else if (platform() == "windows") {
       return runPwsh(appName, "Restore");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testdriverai",
-  "version": "4.0.35",
+  "version": "4.0.36",
   "description": "Next generation autonomous AI agent for end-to-end testing of web & desktop",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
So when I ran v.35 on Wrap I used to get this error 
```
osascript -e 'tell application "Warp" to set miniaturized of every window to true'
27:67: execution error: Warp got an error: Can’t set miniaturized of every window to true. (-10006)
```
And also when the command / action is performed the terminal wasn't reopening, so most of the times it was a guessing game whether to switch the win or wait assuming its thinking lol.

So this fixes it, but it still has a couple of things to note.

- Does not minimize if the terminal is in full screen BUT will bring it back on once the action is performed. 
- In windows, as of now, it minimizes but doesn't reopen the terminal, will try to make a commit for that. (Edit : it's working rn on .39, but still getting the same issue on mac)

Also make sure to bump the version once you merge this, I didn't do it cuz I am unware of when this is gonna merge.