### PR TITLE
min and max scripts for mac needs to be different.

### DIFF
--- a/lib/focus-application.js
+++ b/lib/focus-application.js
@@ -10,10 +10,14 @@ tell application "System Events" to tell process "${windowName}"
     set frontmost to true
 end tell`;
 
-const appleScriptMinMax = (windowName, state) => `
+const appleScriptMin = (windowName) => `
 tell application "System Events" 
-    set value of attribute "AXMinimized" of every window of application process "${windowName}" to ${state}
+    set value of attribute "AXMinimized" of every window of application process "${windowName}" to true
 end tell
+`;
+
+const appleScriptMax = (windowName) => `
+tell application "${windowName}" to activate
 `;
 
 const runPwsh = (appName, method) => {
@@ -42,7 +46,7 @@ async function hideTerminal(appName) {
 
   try {
     if (platform() == "mac") {
-      return await execSync(`osascript -e '${appleScriptMinMax(appName, true)}'`);
+      return await execSync(`osascript -e '${appleScriptMin(appName)}'`);
     } else if (platform() == "linux") {
     } else if (platform() == "windows") {
       return runPwsh(appName, "Minimize");
@@ -57,7 +61,7 @@ async function showTerminal(appName) {
   try {
 
     if (platform() == "mac") {
-      return await execSync(`osascript -e '${appleScriptMinMax(appName, false)}'`);
+      return await execSync(`osascript -e '${appleScriptMax(appName)}'`);
     } else if (platform() == "linux") {
     } else if (platform() == "windows") {
       return runPwsh(appName, "Restore");

--- a/lib/focus-application.js
+++ b/lib/focus-application.js
@@ -20,15 +20,6 @@ const appleScriptMax = (windowName) => `
 tell application "${windowName}" to activate
 `;
 
-const appleScriptMinMax = (windowName, booleanString) => `
-tell application "${windowName}"
-    set windowList to every window
-    repeat with aWindow in windowList
-        set miniaturized of aWindow to ${booleanString}
-    end repeat
-end tell
-`;
-
 const runPwsh = (appName, method) => {
   let script = `powershell -ExecutionPolicy Bypass -Command "& { ${scriptPath} '${appName}' '${method}' }"`;
   return execSync(script, { shell: "powershell" });

--- a/lib/focus-application.js
+++ b/lib/focus-application.js
@@ -10,14 +10,10 @@ tell application "System Events" to tell process "${windowName}"
     set frontmost to true
 end tell`;
 
-const appleScriptMin = (windowName) => `
+const appleScriptMinMax = (windowName, state) => `
 tell application "System Events" 
-    set value of attribute "AXMinimized" of every window of application process "${windowName}" to true
+    set value of attribute "AXMinimized" of every window of application process "${windowName}" to ${state}
 end tell
-`;
-
-const appleScriptMax = (windowName) => `
-tell application "${windowName}" to activate
 `;
 
 const runPwsh = (appName, method) => {
@@ -46,7 +42,7 @@ async function hideTerminal(appName) {
 
   try {
     if (platform() == "mac") {
-      return await execSync(`osascript -e '${appleScriptMin(appName)}'`);
+      return await execSync(`osascript -e '${appleScriptMinMax(appName, true)}'`);
     } else if (platform() == "linux") {
     } else if (platform() == "windows") {
       return runPwsh(appName, "Minimize");
@@ -61,7 +57,7 @@ async function showTerminal(appName) {
   try {
 
     if (platform() == "mac") {
-      return await execSync(`osascript -e '${appleScriptMax(appName)}'`);
+      return await execSync(`osascript -e '${appleScriptMinMax(appName, false)}'`);
     } else if (platform() == "linux") {
     } else if (platform() == "windows") {
       return runPwsh(appName, "Restore");

--- a/lib/focus-application.js
+++ b/lib/focus-application.js
@@ -10,6 +10,16 @@ tell application "System Events" to tell process "${windowName}"
     set frontmost to true
 end tell`;
 
+const appleScriptMin = (windowName) => `
+tell application "System Events" 
+    set value of attribute "AXMinimized" of every window of application process "${windowName}" to true
+end tell
+`;
+
+const appleScriptMax = (windowName) => `
+tell application "${windowName}" to activate
+`;
+
 const appleScriptMinMax = (windowName, booleanString) => `
 tell application "${windowName}"
     set windowList to every window
@@ -42,10 +52,10 @@ async function focusApplication(appName) {
 }
 
 async function hideTerminal(appName) {
- 
+
   try {
     if (platform() == "mac") {
-      return await execSync(`osascript -e '${appleScriptMinMax(appName, 'true')}'`);
+      return await execSync(`osascript -e '${appleScriptMin(appName)}'`);
     } else if (platform() == "linux") {
     } else if (platform() == "windows") {
       return runPwsh(appName, "Minimize");
@@ -60,7 +70,7 @@ async function showTerminal(appName) {
   try {
 
     if (platform() == "mac") {
-      return await execSync(`osascript -e '${appleScriptMinMax(appName, 'false')}'`);
+      return await execSync(`osascript -e '${appleScriptMax(appName)}'`);
     } else if (platform() == "linux") {
     } else if (platform() == "windows") {
       return runPwsh(appName, "Restore");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testdriverai",
-  "version": "4.0.35",
+  "version": "4.0.36",
   "description": "Next generation autonomous AI agent for end-to-end testing of web & desktop",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
So the issue with having a same function is maximizing or activating the terminal doesn't work when the command is executing something in a full screen window.

Made a loom rec explainig / demonstrating as to why - here's the [link](https://www.loom.com/share/462adfb66c2145c1999877c08e370db9?sid=681fc0f5-4085-4f21-8e58-413fa88a7d28)