### PR TITLE
add summarize config

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,7 +233,9 @@ const haveAIResolveError = async (error, markdown, depth = 0, undo = false) => {
   if (errorCounts[safeKey] > errorLimit - 1) {
     console.log(chalk.red("Error loop detected. Exiting."));
     console.log(eMessage);
-    await summarize(eMessage);
+    if (config.TD_SUMMARIZE) {
+      await summarize(eMessage);
+    }
     return await exit(true);
   }
 
@@ -271,7 +273,9 @@ const check = async () => {
 
   if (checkCount >= checkLimit) {
     log.log("info", chalk.red("Exploratory loop detected. Exiting."));
-    await summarize("Check loop detected.");
+    if (config.TD_SUMMARIZE) {
+      await summarize("Check loop detected.");
+    }
     return await exit(true);
   }
 
@@ -317,7 +321,9 @@ const runCommand = async (command, depth) => {
     if (error.fatal) {
       console.log("");
       log.log("info", chalk.red("Fatal Error") + `\n${error.message}`);
-      await summarize(error.message);
+      if (config.TD_SUMMARIZE) {
+        await summarize(error.message);
+      }
       return await exit(true);
     } else {
       return await haveAIResolveError(
@@ -854,8 +860,9 @@ let run = async (file, overwrite = false, shouldExit = true) => {
       console.log(
         `Version mismatch: ${file}. Trying to run a test with v${ymlObj.version} test when this package is v${package.version}.`,
       );
-
-      await summarize("Version mismatch");
+      if (config.TD_SUMMARIZE) {
+        await summarize("Version mismatch");
+      }
       await exit(true);
     }
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -26,6 +26,7 @@ const config = {
   TD_ANALYTICS: true,
   TD_NOTIFY: false,
   TD_MINIMIZE: false,
+  TD_SUMMARIZE: true,
   TD_API_ROOT: "https://replayable-api-production.herokuapp.com",
   TD_DEV: parseValue(process.env["DEV"]),
   TD_PROFILE: false,

--- a/lib/init.js
+++ b/lib/init.js
@@ -94,6 +94,12 @@ module.exports = async () => {
     },
     {
       type: "confirm",
+      name: "TD_SUMMARIZE",
+      message: "Enable error summaries?",
+      initial: true,
+    },
+    {
+      type: "confirm",
       name: "TD_ANALYTICS",
       message: "Send anonymous analytics?",
       initial: true,


### PR DESCRIPTION
This much should be fine for me, there are still some spots where its being called irrespective of the config like [here](https://github.com/testdriverai/testdriverai/blob/4cf4af2849338555f22549544ddfed37eacaa5b0/index.js#L834C2-L834C39) and [here](https://github.com/testdriverai/testdriverai/blob/4cf4af2849338555f22549544ddfed37eacaa5b0/index.js#L846) but they are actually helpful and would need it all the time. 

lmk. 