### PR TITLE
Add support for environment variables in the type command

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -258,6 +258,11 @@ const hover = async (x, y) => {
   return;
 };
 
+const parseEnvVariables = (input) => {
+  const regex = /\${{\s*process\.env\.([a-zA-Z_][a-zA-Z0-9_]*)\s*}}/g;
+  return input.replace(regex, (match, p1) => process.env[p1] || match);
+};
+
 let commands = {
   scroll: scroll,
   click: click,
@@ -362,7 +367,7 @@ let commands = {
   // type a string
   type: async (string) => {
     await redraw.start();
-    string = string.toString();
+    string = parseEnvVariables(string.toString());
     await robot.typeStringDelayed(string, 500);
     await redraw.wait(5000);
     return;


### PR DESCRIPTION
Add support for environment variables in the 'type' command.

* Add `parseEnvVariables` helper function to parse and replace environment variables within the input string.
* Update the `type` command to use `parseEnvVariables` to handle environment variables in the input string before typing it.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/testdriverai/testdriverai/pull/83?shareId=ba7b794f-749c-47e8-a0dd-fa06465955d0).