### PR TITLE
typing repeated chars

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -363,7 +363,10 @@ let commands = {
   type: async (string, delay = 500) => {
     await redraw.start();
     string = string.toString();
-    if (delay > 0)
+    // there is a bug in robotjs that causes repeated characters to only be typed once
+    // so we need to check for repeated characters and type them slowly if so
+    const hasRepeatedChars = /(.)\1/.test(string);
+    if (delay > 0 && hasRepeatedChars)
       await robot.typeStringDelayed(string, delay);
     else
       await robot.typeString(string);


### PR DESCRIPTION
Robotjs will miss repeated character if there is no delay, so we added a global delay.
However this slows down typing globally.
This PR only slows typing conditionally.