### PR TITLE
Add exec command

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -200,7 +200,7 @@ commands:
         speak(`exec ${object.cli}`);
         logger.info(generator.jsonToManual(object));
         notify(generator.jsonToManual(object, false));
-        response = await commands.exec(object.cli, object.stderr);
+        response = await commands.exec(object.cli, object.stderr, object.silent);
         outputs.set(object.output, response);
         break;
       default:

--- a/lib/commander.js
+++ b/lib/commander.js
@@ -8,6 +8,19 @@ const notify = require("./notify");
 const analytics = require("./analytics");
 const marky = require("marky");
 const sdk = require("./sdk");
+const outputs = require("./outputs");
+
+// replace all occurances of ${OUTPUT.ls} with outputs.get("ls") in every possible property of the `object` 
+// this is a recursive function that will go through all the properties of the object
+const replaceOutputs = (obj) => {
+  for (let key in obj) {
+    if (typeof obj[key] === "object") {
+      replaceOutputs(obj[key]);
+    } else if (typeof obj[key] === "string") {
+      obj[key] = obj[key].replace(/\${OUTPUT\.(.*?)}/g, (_, match) => outputs.get(match));
+    }
+  }
+};
 
 // object is a json representation of the individual yml command
 // the process turns markdown -> yml -> json -> js function execution
@@ -37,6 +50,11 @@ commands:
     keys: [command, space]
 \`\`\``;
   } else {
+
+  
+
+    replaceOutputs(object);
+
     let copy = JSON.parse(JSON.stringify(object));
 
     marky.mark(object.command);
@@ -177,6 +195,13 @@ commands:
         logger.info(generator.jsonToManual(object));
         notify(generator.jsonToManual(object, false));
         response = await commands.assert(object.expect, object.async);
+        break;
+      case "exec":
+        speak(`exec ${object.cli}`);
+        logger.info(generator.jsonToManual(object));
+        notify(generator.jsonToManual(object, false));
+        response = await commands.exec(object.cli, object.stderr);
+        outputs.set(object.output, response);
         break;
       default:
         throw new Error(`Command not found: ${object.command}`);

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -664,11 +664,18 @@ let commands = {
   assert: async (assertion, async = false) => {
     return await assert(assertion, true, async);
   },
-  exec: async (cli_command, use_stderr = false) => {
+  exec: async (cli_command, use_stderr = false, silent = false) => {
 
-    const { stdout, stderr } = await exec(cli_command);
+    let args = {};
+    if (silent) {
+      args = { stdio: [] };
+    }
 
-    logger.info(chalk.dim(stdout), true);
+    const { stdout, stderr } = await exec(cli_command, args);
+
+    if (!silent) {
+      logger.info(chalk.dim(stdout), true);
+    }
 
     if (use_stderr) {
       return stderr;

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -24,6 +24,8 @@ const {
   createMarkdownStreamLogger,
 } = require("./logger");
 const { emitter, events } = require("./events.js");
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
 
 const niceSeconds = (ms) => {
   return Math.round(ms / 1000);
@@ -662,6 +664,19 @@ let commands = {
   assert: async (assertion, async = false) => {
     return await assert(assertion, true, async);
   },
+  exec: async (cli_command, use_stderr = false) => {
+
+    const { stdout, stderr } = await exec(cli_command);
+
+    logger.info(chalk.dim(stdout), true);
+
+    if (use_stderr) {
+      return stderr;
+    } else {
+      return stdout;
+    }
+
+  }
 };
 
 module.exports = { commands, assert };

--- a/lib/outputs.js
+++ b/lib/outputs.js
@@ -1,0 +1,12 @@
+let outputs = {};
+
+module.exports = {
+  get: (key) => {
+    return outputs[key] || null;
+  },
+  set: (key, value) => {
+    if (key && value) {
+      outputs[key] = value;
+    }
+  },
+};


### PR DESCRIPTION
Adds:

- `exec` command with properties:
- `cli` the cli command to run
- `output` the name of the output variable

Here is example usage

```yml
version: 4.2.10
session: 67a3fdacd06c99b9c179b566
steps:
  - prompt: exec
    commands:
      - command: exec
        cli: pwd
        silent: false
        output: my_var
  - prompt: type ls
    commands:
      - command: type
        text: ${OUTPUT.my_var}
```

And example output

```sh
❯ node index.js run testdriver/testdriver.yml
Spawning GUI...
Howdy! I'm TestDriver v4.2.13
Working on /Users/ianjennings/Development/testdriverai/testdriver/testdriver.yml

This is beta software!
Join our Discord for help
https://discord.com/invite/cWDFW8DzPm

running /Users/ianjennings/Development/testdriverai/testdriver/testdriver.yml...

exec
command='exec' cli='pwd' output='my_var'
/Users/ianjennings/Development/testdriverai


type ls
command='type' text='/Users/ianjennings/Development/testdriverai
'
/Users/ianjennings/Development/testdriverai
```