### PR TITLE
Silently handle node-notifier errors

### DIFF
--- a/lib/notify.js
+++ b/lib/notify.js
@@ -5,7 +5,7 @@ const { logger } = require("./logger");
 
 module.exports = (message) => {
   if (config["TD_NOTIFY"]) {
-    logger.debug(`${__filename}: (${JSON.stringify(message)})`);
+    logger.debug(`${__filename}: %j`, message);
 
     try {
       notifier.notify({

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,9 +1,11 @@
 const notifier = require("node-notifier");
 const path = require("path");
 const config = require("./config");
+const { logger } = require("./logger");
 
 module.exports = (message) => {
   if (config["TD_NOTIFY"]) {
+    logger.debug(`${__filename}: (${JSON.stringify(message)})`);
     return notifier.notify({
       title: "TestDriver.ai",
       message,

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -6,12 +6,18 @@ const { logger } = require("./logger");
 module.exports = (message) => {
   if (config["TD_NOTIFY"]) {
     logger.debug(`${__filename}: (${JSON.stringify(message)})`);
-    return notifier.notify({
-      title: "TestDriver.ai",
-      message,
-      timeout: 5,
-      icon: path.join(__dirname, "images", "icon.png"),
-      sound: false,
-    });
+
+    try {
+      notifier.notify({
+        title: "TestDriver.ai",
+        message,
+        timeout: 5,
+        icon: path.join(__dirname, "images", "icon.png"),
+        sound: false,
+      });
+    } catch (error) {
+      // Typically, `bad CPU type in executable`
+      logger.debug(__filename, error);
+    }
   }
 };

--- a/lib/speak.js
+++ b/lib/speak.js
@@ -1,8 +1,10 @@
 const say = require("say");
 const config = require("./config");
+const { logger } = require("./logger");
 
 module.exports = (message) => {
   if (config["TD_SPEAK"]) {
+    logger.debug(`${__filename}: (${JSON.stringify(message)})`);
     say.stop();
     if (process.platform === "darwin") {
       say.speak(message, "Fred", 1.2);

--- a/lib/speak.js
+++ b/lib/speak.js
@@ -4,7 +4,7 @@ const { logger } = require("./logger");
 
 module.exports = (message) => {
   if (config["TD_SPEAK"]) {
-    logger.debug(`${__filename}: (${JSON.stringify(message)})`);
+    logger.debug(`${__filename}: %j`, message);
     say.stop();
     if (process.platform === "darwin") {
       say.speak(message, "Fred", 1.2);


### PR DESCRIPTION
```shell
/Users/eric/Projects/testdriverai/testdriverai/node_modules/node-notifier/vendor/mac.noindex/terminal-notifier.app/Contents/MacOS/terminal-notifie
r -title "TestDriver.ai" -message "command='type' text='hi'" -timeout "5" -appIcon "/Users/eric/Projects/testdriverai/testdriverai/lib/images/icon.png" -json "true"
zsh: bad CPU type in executable: /Users/eric/Projects/testdriverai/testdriverai/node_modules/node-notifier/vendor/mac.noindex/terminal-notifier.app/Contents/MacOS/terminal-notifier
```