### PR TITLE
Only log code & reason if they're set

### DIFF
--- a/electron/overlay.js
+++ b/electron/overlay.js
@@ -114,7 +114,6 @@ app.whenReady().then(() => {
   // window.webContents.openDevTools();
 
   ipc.serve(() => {
-    console.error("Serving IPC");
     for (const event of eventsArray) {
       ipc.server.on(event, (data) => {
         if (event === "show-window") {
@@ -137,7 +136,6 @@ app.whenReady().then(() => {
   );
 
   ipc.server.on("connect", () => {
-    console.error("Client connected");
     clearTimeout(timeout);
   });
 


### PR DESCRIPTION
This reduces the noisy output:

```console
eric  …/_l20wtfj41n2dx0xyhb8xd740000gn/T/tmp.PDxTlOLJBS   v23.11.0  ♥ 14:31  TD_API_ROOT=http://localhost:1337 npx testdriverai
Serving IPC
Client connected
Howdy! I'm TestDriver v5.7.26
This is beta software!

Join our Discord for help
https://discord.com/invite/cWDFW8DzPm

Created /private/var/folders/4w/_l20wtfj41n2dx0xyhb8xd740000gn/T/tmp.PDxTlOLJBS/testdriver/testdriver.yaml
Working on /private/var/folders/4w/_l20wtfj41n2dx0xyhb8xd740000gn/T/tmp.PDxTlOLJBS/testdriver/testdriver.yaml

Warning! Local mode sends screenshots of the desktop to our API. Set `TD_VM` to run in a secure VM.
Read More: https://docs.testdriver.ai/security/agent

⠙Exiting with code 0 and reason: "IPC Client disconnected"
Exiting with code 0 and reason: "IPC Client disconnected”
```