### PR TITLE
chore: openDevTools when TD_DEV

### DIFF
--- a/electron/overlay.js
+++ b/electron/overlay.js
@@ -111,7 +111,9 @@ app.whenReady().then(() => {
   });
 
   // open developer tools
-  // window.webContents.openDevTools();
+  if (process.env.TD_DEV) {
+    window.webContents.openDevTools({ mode: "detach" });
+  }
 
   ipc.serve(() => {
     for (const event of eventsArray) {


### PR DESCRIPTION
For https://www.notion.so/Mouse-click-UI-dots-don-t-go-away-should-go-away-after-a-timeout-1ed6adb97c8880178234feb3d3aa1d2a, I needed to inspect the DOM.

This made it possible by default when running `TD_DEV`