### PR TITLE
ci: switch publish workflow from beta to canary tag

### DIFF
--- a/.github/workflows/publish-acceptance-tests.yml
+++ b/.github/workflows/publish-acceptance-tests.yml
@@ -17,8 +17,8 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  publish-beta:
-    name: Publish testdriverai@beta
+  publish-canary:
+    name: Publish testdriverai@canary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,9 +27,13 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "20"
+      - name: Version
+        # Unique prerelease version specific to this commit
+        # v5.7.40-canary.09e0e4c.0
+        run: npm version --no-git-tag-version prerelease --preid=canary.$(git rev-parse --short HEAD)
       - uses: JS-DevTools/npm-publish@v3
         with:
-          tag: "beta"
+          tag: "canary"
           token: ${{ secrets.NPM_AUTH_TOKEN }}
 
   gather-test-files:
@@ -53,7 +57,7 @@ jobs:
     name: Run Tests
     needs:
       - gather-test-files
-      - publish-beta
+      - publish-canary
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -68,7 +72,7 @@ jobs:
         id: testdriver
         uses: testdriverai/action@main
         with:
-          version: "beta"
+          version: "canary"
           os: ${{ contains(matrix.os, 'windows') && 'windows' || 'linux' }}
           prerun: |
             exit


### PR DESCRIPTION
- Updated GitHub Actions workflow to publish pre-release versions under the "canary" tag instead of "beta"  
- Renamed the publish job accordingly and changed the npm publish tag to "canary"  
- Set unique prerelease versions including the commit hash for better traceability  
- Adjusted test jobs to depend on the new canary publish job and use the canary version for testing  
- Updated package.json version to reflect the canary pre-release state  
- Improved release management by clearly distinguishing unstable builds from beta releases