### PR TITLE
Add Acecptance Tests to pull_requests, but skip them

### DIFF
--- a/.github/workflows/publish-acceptance-tests.yml
+++ b/.github/workflows/publish-acceptance-tests.yml
@@ -8,8 +8,12 @@ permissions:
   statuses: write
 
 on:
-  # Run in Merge Queue rather than individual PRs
+  # Required checks have to exist in both PRs & Merge Queue:
+  # https://github.com/orgs/community/discussions/103114#discussioncomment-8359045
+  pull_request:
+  # Run in Merge Queue
   merge_group:
+    types: [checks_requested]
   # Through the GitHub UI
   workflow_dispatch:
   # Run every day at midnight to ensure CLI -> API works
@@ -18,6 +22,8 @@ on:
 
 jobs:
   publish-canary:
+    # Only run this job if in the Merge Queue
+    if: github.event_name == 'merge_group'
     name: Publish testdriverai@canary
     runs-on: ubuntu-latest
     steps:
@@ -37,6 +43,8 @@ jobs:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
 
   gather-test-files:
+    # Only run this job if in the Merge Queue
+    if: github.event_name == 'merge_group'
     name: Gather Test Files
     runs-on: ubuntu-latest
     outputs:
@@ -54,6 +62,7 @@ jobs:
           echo "files=$FILES_JSON" >> $GITHUB_OUTPUT
 
   run-tests:
+    # Should be automatically skipped outside of Merge Queue
     name: Run Tests
     needs:
       - gather-test-files
@@ -116,6 +125,7 @@ jobs:
           retention-days: 1
 
   create-snippets-commit:
+    # Should be automatically skipped outside of Merge Queue
     name: Commit Snippets
     needs: run-tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
See:
https://github.com/orgs/community/discussions/103114#discussioncomment-8359045

If this works, then I can add a branch protection rule to https://github.com/testdriverai/testdriverai/settings/branch_protection_rules/54177906 that requires this check:

> ![Screenshot 2025-06-02 at 12 50 33 PM](https://github.com/user-attachments/assets/17e304b8-cfd4-477e-b640-ecac3b5a5dfc)

That *should* force it to run in the Merge Queue.

