### PR TITLE
fix right and left scroll

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -227,13 +227,13 @@ const scroll = async (direction = "down", amount = 300, method = "mouse") => {
     case "left":
       config.TD_VM
         ? console.log("Not Supported")
-        : await robot.scrollMouse(amount * -1, 0);
+        : await robot.scrollMouse(amount, 0);
       await redraw.wait(2500);
       break;
     case "right":
       config.TD_VM
         ? console.log("Not Supported")
-        : await robot.scrollMouse(amount, 0);
+        : await robot.scrollMouse(amount * -1, 0);
       await redraw.wait(2500);
       break;
     default:


### PR DESCRIPTION
This PR fixes right and left scroll functionality.
Idk how to explain this, other than some testing during the birth would have been nice. 
Had an usecase where I needed to scroll right, it didn't work, saw the [robotjs](https://github.com/octalmage/robotjs) repo, couldn't really understand / point out to the implementation.
So wrote a simple script 
```js
const robot = require("robotjs");
console.log("Waiting 5 seconds before scrolling...");
setTimeout(() => {
  robot.scrollMouse(300, 0);

  console.log("Horizontal scroll completed!");
}, 5000);
```
And experimented, `scrollMouse` params are `(x, y)` direction, `300` means usually, generally, we understand as scroll right right ? guess what, surprise surprise, its actually `-300`.  

`300` will scroll to left, which most of the times nothing happens, and we would have to scratch our head thinking why nothing's happening 😅