### PR TITLE
Fix empty file (testdriver/testdriverai.yaml) creation during init

### DIFF
--- a/agent.js
+++ b/agent.js
@@ -1260,9 +1260,11 @@ const start = async () => {
   }
 
   // if thisFile doesn't exist, create it
+  if (thisCommand !== "init" && thisCommand !== "upload-secrets") { // thisFile def to testdriver/testdriver.yaml, during init, it just creates an empty file
   if (!fs.existsSync(thisFile)) {
     fs.writeFileSync(thisFile, "");
-    logger.info(theme.dim(`Created ${thisFile}`));
+      logger.info(theme.dim(`Created ${thisFile}`));
+    }
   }
 
   if (config.TD_API_KEY) {


### PR DESCRIPTION
@ericclemmons I had reported this on [Notion](https://www.notion.so/VS-Code-Testing-as-of-5-3-1e86adb97c888089bb36c014efc4f042?source=copy_link#1e86adb97c88802197b5c7fef720804f) 
You might have mistakenly marked it as done I think.
Got a client who reported this today, so here's the fix. 

It's mostly hotfix, we need to refractor the "init" process, some of it is in `agent.js` and some in `lib/init.js`