### PR TITLE
add delay back to type

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -428,7 +428,7 @@ let commands = {
         await robot.typeStringDelayed(string, delay);
       else await robot.typeString(string);
     }
-    // await redraw.wait(5000);
+    await redraw.wait(5000);
     return;
   },
   // press keys


### PR DESCRIPTION
Redraw needs to be implemented in `type`, or we see race conditions where a loading dropdown may be loading while the next command executes.