### PR TITLE
Remove incorrect mermaid chart from prerun docs

### DIFF
--- a/docs/guide/lifecycle-prerun.mdx
+++ b/docs/guide/lifecycle-prerun.mdx
@@ -65,19 +65,6 @@ Note that the `prerun` script is found in the GitHub Actions workflow file for d
 
 ### Prerun flow
 
-```mermaid
-graph TD
-    A{Is the test deployed to CI?}
-    A -->|Yes| B[Run .github/workflows/testdriver.yml]
-    B --> F
-    A -->|No| C{Is prerun available at ./lifecycle/prerun.yaml}
-    C -->|Yes| D[Run ./lifecycle/prerun.yaml]
-    C -->|No| F
-    D --> F[Run ./testdriver/testfile.yaml]
-```
-
----
-
 ## Examples
 
 For example, the `prerun.yaml` file can be combined with the [`exec`](/commands/exec) command to open the Chrome browser and navigate to a page, similar to the example provided above. This ensures that the test environment is properly set up before the test starts. _Note that the prerun is a TestDriver test file like any other, combining commands to complete a task_.


### PR DESCRIPTION
The `lifecycle/prerun.yaml` script is run always, no matter the environment.
The `prerun` value from GitHub actions is only run via GitHub actions and only affects Windows machines.