### PR TITLE
TD-1983 – Default TD_VM to `true`

### DIFF
--- a/docs/guide/environment-variables.mdx
+++ b/docs/guide/environment-variables.mdx
@@ -1,32 +1,24 @@
----
-title: "Environment Variables"
-sidebarTitle: "Environment Variables"
-description: "Learn how which environment variables are supported by TestDriver."
-icon: "key"
----
-
-import GitignoreWarning from '/snippets/gitignore-warning.mdx'
-
-
 The supported environment variables in TestDriver are:
 
-| Variable | Type |         Description          |
-|:--------:|:----:|:----------------------------|
-| `TD_SPEAK` | `boolean` | Use text to speech to hear TestDriver speak as commands are run. Helpful when you don't use `TD_OVERLAY` and just plain fun. |
-| `TD_ANALYTICS` | `boolean` | Send analytics to TestDriver servers. This helps provide feedback to inform our roadmap. |
-| `TD_NOTIFY` | `boolean` | Send desktop notifications when commands are run. |
-| `TD_MINIMIZE` | `boolean` | When not using VMs, minimize the terminal window / calling app when running commands. Useful if you only have one monitor, you don't want the terminal to show up. |
-| `TD_API_ROOT` | `string` | Developer only. Set API root to another URL. For on-prem. |
-| `TD_API_KEY` | `string` | Set this to spawn VMs with TestDriver Pro. |
-| `TD_OVERLAY` | `boolean` | Spawn overlay window that shows both the TestDriver console output, and draws the cursor and squares on the screen as TestDriver thinks. Defaults to true if not provided.|
-| `TD_VM` | `boolean` | Run commands in a Linux VM instead of on own desktop. Requires API key. |
-| `TD_VM_RESOLUTION` | `string` | Change resolution when TD_VM is true. Format like `1280x1024`. |
-| `TD_TYPE` | `string` | Set the type of test to run. Can be `website`, `desktop`, or `mobile`. Not required. |
+|      Variable      |   Type    | Description                                                                                                                                                                |
+| :----------------: | :-------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|     `TD_SPEAK`     | `boolean` | Use text to speech to hear TestDriver speak as commands are run. Helpful when you don't use `TD_OVERLAY` and just plain fun.                                               |
+|   `TD_ANALYTICS`   | `boolean` | Send analytics to TestDriver servers. This helps provide feedback to inform our roadmap.                                                                                   |
+|    `TD_NOTIFY`     | `boolean` | Send desktop notifications when commands are run.                                                                                                                          |
+|   `TD_MINIMIZE`    | `boolean` | When not using VMs, minimize the terminal window / calling app when running commands. Useful if you only have one monitor, you don't want the terminal to show up.         |
+|   `TD_API_ROOT`    | `string`  | Developer only. Set API root to another URL. For on-prem.                                                                                                                  |
+|    `TD_API_KEY`    | `string`  | Set this to spawn VMs with TestDriver Pro.                                                                                                                                 |
+|    `TD_OVERLAY`    | `boolean` | Spawn overlay window that shows both the TestDriver console output, and draws the cursor and squares on the screen as TestDriver thinks. Defaults to true if not provided. |
+|      `TD_VM`       | `boolean` | Run commands in a Linux VM instead of on own desktop. Requires API key. (Default: `true`)                                                                                  |
+| `TD_VM_RESOLUTION` | `string`  | Change resolution when TD_VM is true. Format like `1280x1024`. (Default: `1024x768`)                                                                                       |
+|     `TD_TYPE`      | `string`  | Set the type of test to run. Can be `website`, `desktop`, or `mobile`. Not required.                                                                                       |
 
 <GitignoreWarning />
 
 ---
+
 ## Example
+
 ```
 TD_VM=true
 TD_API_KEY=your_api_key
@@ -38,18 +30,25 @@ TD_ANALYTICS=true
 TD_OVERLAY=false
 
 ```
+
 In this example `.env` file, we're running a website test in a local Linux VM with a resolution of 1024x768. The terminal will be minimized, and the overlay won't be shown. Analytics will be sent to TestDriver servers.
 
 ---
-## Using environment variables in deployed tests
-When running tests in a deployed environment, you can set environment variables in the `env` section of your GitHub Actions workflow file. This allows you to customize the behavior of TestDriver based on the environment in which it's running. Setup any environment variables you plan to use in the deployed test in your `.env` file and add them  as GitHub secrets. 
 
-<Tip>For more info on how to set up environment variables with GitHub Actions, see [Managing Secrets in GitHub Actions](/actions/secrets)</Tip>
+## Using environment variables in deployed tests
+
+When running tests in a deployed environment, you can set environment variables in the `env` section of your GitHub Actions workflow file. This allows you to customize the behavior of TestDriver based on the environment in which it's running. Setup any environment variables you plan to use in the deployed test in your `.env` file and add them as GitHub secrets.
+
+<Tip>
+  For more info on how to set up environment variables with GitHub Actions, see
+  [Managing Secrets in GitHub Actions](/actions/secrets)
+</Tip>
 
 In this example, there is both a `TD_TEST_USERNAME` and `TD_TEST_PASSWORD` variables in the local `.env` file. This file is used to run tests locally and mask credentials used to log in to a website. When deployed, these variables are stored as secrets in GitHub and are passed to the TestDriver action when it runs.
 
 ---
-## Example 2 
+
+## Example 2
 
 ```
 TD_VM=false

--- a/lib/config.js
+++ b/lib/config.js
@@ -31,7 +31,7 @@ const config = {
   TD_PROFILE: false,
   TD_OVERLAY: true,
   TD_SECRET: null,
-  TD_VM: false,
+  TD_VM: true,
   TD_OVERLAY_ID: null,
   TD_VM_RESOLUTION: [1024, 768],
   TD_IPC_ID: `testdriverai_${process.pid}`,


### PR DESCRIPTION
> https://www.notion.so/Make-linux-the-default-runner-20c6adb97c8880a2b1b5c484c86bb8aa?source=copy_link

This is already the default in https://github.com/testdriverai/testdriverai/blob/main/lib/init.js#L89

So when TD_VM *is not set in `.env` or the environment*, it will default ot `true`.