### PR TITLE
TD-2151 – throw if an env variable is missing

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -3,6 +3,7 @@ const Parser = require("markdown-parser");
 const yaml = require("js-yaml");
 const Ajv = require("ajv");
 const theme = require("./theme");
+const { logger } = require("./logger");
 
 let parser = new Parser();
 
@@ -116,6 +117,14 @@ function interpolate(yaml, vars) {
   });
   // Replace \$ with $
   newyaml = newyaml.replace(/\\(\${[^}]+})/g, "$1");
+
+  // Warn if any variables remain unreplaced
+  const unreplaced = newyaml.match(/\${([^}]+)}/g);
+  if (unreplaced) {
+    throw new Error(
+      `Warning: Environment missing values for variables: ${[...new Set(unreplaced)].join(", ")}. There may be a typo in your prompt or environment variables.`,
+    );
+  }
 
   return newyaml;
 }


### PR DESCRIPTION
> https://www.notion.so/warning-throw-when-prompt-has-a-missing-environment-variable-2146adb97c8881aa843ef6f70daee641?source=copy_link

```console
> Login
command='run' file='testdriver/snippets/login.yml'
testdriver/snippets/login.yml (start)
Error detected, but recovery mode is not enabled.
To attempt automatic recovery, re-run with the --heal flag.
Fatal Error
Warning: Environment missing values for variables: ${TD_TEST_USERNAME}. There may be a typo in your prompt or environment variables.

reviewing test...
summarizing...
    The test failed.
    
    The failure occurred because the environment variable 
    ${TD_TEST_USERNAME} was not defined, so the script
    couldn’t substitute a username during the login step.
    Without that value, the login form couldn’t be populated
    and the test stalled.

```