### PR TITLE
TD-2165 – Add `path` support for `scroll-until-image`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 lib/subimage/opencv.js
 node_modules
+schema.json

--- a/docs/commands/scroll-until-image.mdx
+++ b/docs/commands/scroll-until-image.mdx
@@ -11,11 +11,12 @@ The `scroll-until-image` command is used to scroll the screen in a specified dir
 
 ## Arguments
 
-| Argument      | Type     | Description                                                                 |
-|---------------|----------|-----------------------------------------------------------------------------|
-| `description` | `string` | A description of the image and what it represents.                         |
-| `direction`   | `string` | The direction to scroll. Available directions are: `up`, `down`, `left`, `right`. |
-| `distance`    | `number` | (Optional) The maximum number of pixels to scroll before giving up. Default is `1200`. |
+| Argument      | Type     | Description                                                                                                                        |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `description` | `string` | A description of the image and what it represents.                                                                                 |
+| `direction`   | `string` | The direction to scroll. Available directions are: `up`, `down`, `left`, `right`.                                                  |
+| `distance`    | `number` | (Optional) The maximum number of pixels to scroll before giving up. Default is `1200`.                                             |
+| `path`        | `string` | The relative path to the image file that needs to be matched on the screen. Don't include `testdriver/screenshots/*/` in the path. |
 
 ## Example usage
 
@@ -25,15 +26,26 @@ description: Submit at the bottom of the form
 direction: down
 ```
 
+Or, you can use the `path` argument to match an image on the screen (similar to [`match-image`](./match-image)):
+
+```yaml
+command: scroll-until-image
+path: button.png
+direction: down
+```
+
 ## Protips
+
 - Use clear and concise descriptions for the image to improve detection accuracy.
 - Adjust the `distance` value to control how far the command scrolls before giving up.
 - Combine this command with other commands like `hover-image` or `match-image` to interact with the located image.
 
 ## Gotchas
+
 - If the image can't be located within the specified `distance`, the command will fail.
 - Ensure the description accurately represents the image to avoid detection issues.
 
 ## Notes
+
 - The `scroll-until-image` command is ideal for navigating to visual elements that are off-screen and can't be located using text-based commands.
 - This command supports both vertical and horizontal scrolling for flexible navigation.

--- a/lib/commander.js
+++ b/lib/commander.js
@@ -183,9 +183,10 @@ commands:
             object.method,
           );
           break;
-        case "scroll-until-image":
-          speak(`scrolling until ${object.description}`);
-          server.broadcast("status", `scrolling until ${object.description}`);
+        case "scroll-until-image": {
+          const needle = object.description || object.path;
+          speak(`scrolling until ${needle}`);
+          server.broadcast("status", `scrolling until ${needle}`);
           logger.info(generator.jsonToManual(object));
           notify(generator.jsonToManual(object, false));
           response = await commands["scroll-until-image"](
@@ -193,8 +194,10 @@ commands:
             object.direction,
             object.distance,
             object.method,
+            object.path,
           );
           break;
+        }
         case "focus-application":
           speak(`focusing ${object.name}`);
           server.broadcast("status", `focusing ${object.name}`);

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -415,6 +415,8 @@ let commands = {
         await hover(result.centerX, result.centerY);
       }
     }
+
+    return true;
   },
   // type a string
   type: async (string, delay = 250) => {
@@ -691,9 +693,20 @@ let commands = {
     direction = "down",
     maxDistance = 10000,
     method = "keyboard",
+    path,
   ) => {
+    const needle = description || path;
+
+    if (!needle) {
+      throw new AiError("No description or path provided");
+    }
+
+    if (description && path) {
+      throw new AiError("Only one of description or path can be provided");
+    }
+
     logger.info(
-      theme.dim(`scrolling for an image matching "${description}"...`),
+      theme.dim(`scrolling for an image matching "${needle}"...`),
       true,
     );
 
@@ -702,15 +715,21 @@ let commands = {
     let passed = false;
 
     while (scrollDistance <= maxDistance && !passed) {
-      passed = await assert(
-        `An image matching the description "${description}" appears on screen.`,
-        false,
-        false,
-      );
+      if (description) {
+        passed = await assert(
+          `An image matching the description "${description}" appears on screen.`,
+          false,
+          false,
+        );
+      }
+
+      if (path) {
+        // Don't throw if not found. We only want to know if it's found or not.
+        passed = await commands["match-image"](path, null).catch(console.warn);
+      }
 
       if (!passed) {
         logger.info(
-          "info",
           theme.dim(`scrolling ${direction} ${incrementDistance} pixels...`),
           true,
         );
@@ -720,11 +739,11 @@ let commands = {
     }
 
     if (passed) {
-      logger.info(theme.dim(`"${description}" found!`), true);
+      logger.info(theme.dim(`"${needle}" found!`), true);
       return;
     } else {
       throw new AiError(
-        `Scrolled ${scrollDistance} pixels without finding an image matching "${description}"`,
+        `Scrolled ${scrollDistance} pixels without finding an image matching "${needle}"`,
         true,
       );
     }

--- a/schema.json
+++ b/schema.json
@@ -437,6 +437,9 @@
                       "description": {
                         "type": "string"
                       },
+                      "path": {
+                        "type": "string"
+                      },
                       "direction": {
                         "type": "string",
                         "enum": [
@@ -450,8 +453,11 @@
                         "type": "integer"
                       }
                     },
+                    "anyOf": [
+                      { "required": ["description"] },
+                      { "required": ["path"] }
+                    ],
                     "required": [
-                      "description",
                       "direction"
                     ]
                   }


### PR DESCRIPTION

> https://www.notion.so/scroll-until-image-should-also-accept-a-path-to-use-match-image-2166adb97c888122aaf0ecc97fbe572c?source=copy_link

- - Added support for using either `description` or `path` as the image identifier in the `scroll-until-image` command.
- Updated the schema to require either `path` or `description`, enhancing flexibility and accuracy.
- Modified `scroll-until-image` to pass `object.path`.
- Implemented assertion for `description` and matching logic for `path` in image matching.
- Updated `match-image` to return `throw` or `true`.
- Improved documentation with known issues and detailed scrolling workarounds, including keyboard-based scrolling.
- Added `schema.json` to `.prettierignore`