### PR TITLE
test: Environment Variables are passed through to VM

### DIFF
--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -43,10 +43,10 @@ jobs:
           key: ${{ secrets.TESTDRIVER_API_KEY }}
           os: linux
           prerun: |
-            echo "SOME_SECRET: $SOME_SECRET"
-            echo "SOME_SCRIPT: $SOME_SCRIPT"
-            echo "TD_SOME_SECRET: $TD_SOME_SECRET"
-            echo "TD_SOME_SCRIPT: $TD_SOME_SCRIPT"
+            printf 'SOME_SECRET:%s\n' "$SOME_SECRET"
+            printf 'SOME_SCRIPT:%s\n' "$SOME_SCRIPT"
+            printf 'TD_SOME_SECRET:%s\n' "$TD_SOME_SECRET"
+            printf 'TD_SOME_SCRIPT:%s\n' "$TD_SOME_SCRIPT"
           prompt: |
             Page should contain "TestDriver.ai Sandbox"
         env:

--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -13,45 +13,22 @@ on:
 
 jobs:
   test:
-    name: "Run TestDriver"
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
-
     env:
-      GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+      SOME_SECRET: "secrets.SOME_SECRET"
+      SOME_SCRIPT: |
+        echo "SOME_SECRET: $SOME_SECRET"
+      TD_API_KEY: ${{ secrets.TD_API_KEY }}
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Setup Google Auth
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}"
-
-      - name: Setup gcloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Get secrets from Secret Manager
-        id: secrets
-        uses: google-github-actions/get-secretmanager-secrets@v2
-        with:
-          export_to_environment: true
-          secrets: |
-            TD_API_KEY:projects/17279051920/secrets/TESTDRIVER_API_KEY:latest
-            TD_SSH_SETUP_SCRIPT:projects/17279051920/secrets/testdriver_ssh_setup_script:latest
-            TD_SSH_KEY:projects/17279051920/secrets/TESTDRIVER_SSH_KEY:latest
-
-      - name: Export secrets to environment
+      - uses: actions/checkout@v4
+      - name: Re-export secrets to environment
         run: |
-          echo ${TD_SSH_KEY} > key
-          cat key
-          echo "TD_API_KEY=$(cat key)" >> $GITHUB_ENV
-          echo ${TD_SSH_SETUP_SCRIPT} > ssh_setup_script
-          cat ssh_setup_script
-          echo "TD_SSH_SETUP_SCRIPT=$(cat ssh_setup_script)" >> $GITHUB_ENV
+          echo ${TD_API_KEY} > key
+          echo "TD_API_KEY_2=$(cat key)" >> $GITHUB_ENV
 
       - name: Run TestDriver
         id: testdriver

--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -1,0 +1,97 @@
+name: TestDriver QA
+run-name: Running TestDriver QA
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: "Run TestDriver"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Google Auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}"
+
+      - name: Setup gcloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Get secrets from Secret Manager
+        id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@v2
+        with:
+          export_to_environment: true
+          secrets: |
+            TD_API_KEY:projects/17279051920/secrets/TESTDRIVER_API_KEY:latest
+            TD_SSH_SETUP_SCRIPT:projects/17279051920/secrets/testdriver_ssh_setup_script:latest
+            TD_SSH_KEY:projects/17279051920/secrets/TESTDRIVER_SSH_KEY:latest
+
+      - name: Export secrets to environment
+        run: |
+          echo ${TD_SSH_KEY} > key
+          cat key
+          echo "TD_API_KEY=$(cat key)" >> $GITHUB_ENV
+          echo ${TD_SSH_SETUP_SCRIPT} > ssh_setup_script
+          cat ssh_setup_script
+          echo "TD_SSH_SETUP_SCRIPT=$(cat ssh_setup_script)" >> $GITHUB_ENV
+
+      - name: Run TestDriver
+        id: testdriver
+        uses: testdriverai/action@main
+        with:
+          key: ${{ env.TD_API_KEY }}
+          os: linux
+          create-pr: false
+          pr-branch: testdriver-results
+          pr-title: "TestDriver QA Results"
+          pr-test-filename: testdriver-results.yaml
+          prerun: |
+            echo "TD_SSH_SETUP_SCRIPT: $TD_SSH_SETUP_SCRIPT"
+          prompt: |
+            1. check that Visual Studio Code is visible with the cdc_fifo folder open
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TD_VM: true
+          TD_VM_RESOLUTION: 1280x1024
+          TD_OVERLAY: true
+          TD_ANALYTICS: false
+          FORCE_COLOR: "3"
+          TD_API_KEY: ${{ env.TD_API_KEY }}
+          TD_SSH_SETUP_SCRIPT: ${{ env.TD_SSH_SETUP_SCRIPT }}
+          TD_SSH_KEY: ${{ env.TD_SSH_KEY }}
+
+      - name: Comment results on PR
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## 🧪 TestDriver QA Report
+
+            **✅ Summary:**  
+            ${{ steps.testdriver.outputs.summary || 'No summary available.' }}
+
+            **🖼️ Markdown Report:**  
+            ${{ steps.testdriver.outputs.markdown || 'No markdown report.' }}
+
+            **🔗 Replay Link:**  
+            [View Dashcam Replay](${{ steps.testdriver.outputs.link || '#' }})

--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -26,13 +26,15 @@ jobs:
 
       - name: Re-export secrets to environment
         run: |
-          echo "SOME_SECRET_2=${SOME_SECRET}" >> $GITHUB_ENV
+          echo "TD_SOME_SECRET=${SOME_SECRET}" >> $GITHUB_ENV
+          echo "TD_SOME_SCRIPT=${SOME_SCRIPT}" >> $GITHUB_ENV
 
       - name: Verify secrets are exported to environment
         run: |
-          printf '%s\n' "$SOME_SECRET"
-          printf '%s\n' "$SOME_SECRET_2"
-          printf '%s\n' "$SOME_SCRIPT"
+          printf 'SOME_SECRET:%s\n' "$SOME_SECRET"
+          printf 'SOME_SCRIPT:%s\n' "$SOME_SCRIPT"
+          printf 'TD_SOME_SECRET:%s\n' "$TD_SOME_SECRET"
+          printf 'TD_SOME_SCRIPT:%s\n' "$TD_SOME_SCRIPT"
 
       - name: Run TestDriver
         id: testdriver
@@ -41,9 +43,10 @@ jobs:
           key: ${{ secrets.TESTDRIVER_API_KEY }}
           os: linux
           prerun: |
-            echo "SOME_SECRET: ${SOME_SECRET}"
-            echo "SOME_SECRET_2: ${SOME_SECRET_2}"
-            echo "SOME_SCRIPT: ${SOME_SCRIPT}"
+            echo "SOME_SECRET: $SOME_SECRET"
+            echo "SOME_SCRIPT: $SOME_SCRIPT"
+            echo "TD_SOME_SECRET: $TD_SOME_SECRET"
+            echo "TD_SOME_SCRIPT: $TD_SOME_SCRIPT"
           prompt: |
             Page should contain "TestDriver.ai Sandbox"
         env:

--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -35,10 +35,6 @@ jobs:
         with:
           key: ${{ env.TD_API_KEY }}
           os: linux
-          create-pr: false
-          pr-branch: testdriver-results
-          pr-title: "TestDriver QA Results"
-          pr-test-filename: testdriver-results.yaml
           prerun: |
             printenv
           prompt: |
@@ -54,20 +50,3 @@ jobs:
           TD_API_KEY: ${{ env.TD_API_KEY }}
           TD_SSH_SETUP_SCRIPT: ${{ env.TD_SSH_SETUP_SCRIPT }}
           TD_SSH_KEY: ${{ env.TD_SSH_KEY }}
-
-      - name: Comment results on PR
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ## 🧪 TestDriver QA Report
-
-            **✅ Summary:**  
-            ${{ steps.testdriver.outputs.summary || 'No summary available.' }}
-
-            **🖼️ Markdown Report:**  
-            ${{ steps.testdriver.outputs.markdown || 'No markdown report.' }}
-
-            **🔗 Replay Link:**  
-            [View Dashcam Replay](${{ steps.testdriver.outputs.link || '#' }})

--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -20,7 +20,6 @@ jobs:
       SOME_SECRET: "secrets.SOME_SECRET"
       SOME_SCRIPT: |
         echo "SOME_SECRET: $SOME_SECRET"
-      TD_API_KEY: ${{ secrets.TD_API_KEY }}
 
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +31,7 @@ jobs:
         id: testdriver
         uses: testdriverai/action@main
         with:
-          key: ${{ secrets.TD_API_KEY }}
+          key: ${{ secrets.TESTDRIVER_API_KEY }}
           os: linux
           prerun: |
             echo "SOME_SECRET: $SOME_SECRET"

--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -23,9 +23,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Re-export secrets to environment
         run: |
           echo "SOME_SECRET_2=${SOME_SECRET}" >> $GITHUB_ENV
+
+      - name: Verify secrets are exported to environment
+        run: |
+          printf '%s\n' "$SOME_SECRET"
+          printf '%s\n' "$SOME_SECRET_2"
+          printf '%s\n' "$SOME_SCRIPT"
 
       - name: Run TestDriver
         id: testdriver

--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -17,24 +17,24 @@ jobs:
       run:
         shell: bash
     env:
+      # Pretend we have a secret from GitHub
       SOME_SECRET: "secrets.SOME_SECRET"
-      SOME_SCRIPT: |
-        echo "SOME_SECRET: $SOME_SECRET"
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Re-export secrets to environment
+      - name: Expose secrets to TestDriver with TD_* prefix
         run: |
           echo "TD_SOME_SECRET=${SOME_SECRET}" >> $GITHUB_ENV
-          echo "TD_SOME_SCRIPT=${SOME_SCRIPT}" >> $GITHUB_ENV
 
-      - name: Verify secrets are exported to environment
+      - name: Assert that all secrets are correctly in GitHub environment
         run: |
-          printf 'SOME_SECRET:%s\n' "$SOME_SECRET"
-          printf 'SOME_SCRIPT:%s\n' "$SOME_SCRIPT"
-          printf 'TD_SOME_SECRET:%s\n' "$TD_SOME_SECRET"
-          printf 'TD_SOME_SCRIPT:%s\n' "$TD_SOME_SCRIPT"
+          if [[ "$SOME_SECRET" != "secrets.SOME_SECRET" ]]; then
+            echo "SOME_SECRET is not set correctly: $SOME_SECRET"; exit 1;
+          fi
+          if [[ "$TD_SOME_SECRET" != "secrets.SOME_SECRET" ]]; then
+            echo "TD_SOME_SECRET is not set correctly: $TD_SOME_SECRET"; exit 1;
+          fi
 
       - name: Run TestDriver
         id: testdriver
@@ -43,14 +43,11 @@ jobs:
           key: ${{ secrets.TESTDRIVER_API_KEY }}
           os: linux
           prerun: |
-            printf 'SOME_SECRET:%s\n' "$SOME_SECRET"
-            printf 'SOME_SCRIPT:%s\n' "$SOME_SCRIPT"
-            printf 'TD_SOME_SECRET:%s\n' "$TD_SOME_SECRET"
-            printf 'TD_SOME_SCRIPT:%s\n' "$TD_SOME_SCRIPT"
+            echo "# Asserting all values are empty in testdriverai/action's prerun"
+            if [[ -n "$SOME_SECRET" ]]; then echo "SOME_SECRET should be empty"; exit 1; fi
+            if [[ -n "$TD_SOME_SECRET" ]]; then echo "TD_SOME_SECRET should be empty"; exit 1; fi
           prompt: |
             Page should contain "TestDriver.ai Sandbox"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOME_SECRET: ${{ env.SOME_SECRET }}
-          SOME_SCRIPT: ${{ env.SOME_SCRIPT }}
           TD_WEBSITE: "https://testdriver-sandbox.vercel.app"

--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -1,5 +1,4 @@
-name: TestDriver QA
-run-name: Running TestDriver QA
+name: Test – Environment Passthrough to VM
 
 permissions:
   contents: read
@@ -41,7 +40,7 @@ jobs:
           pr-title: "TestDriver QA Results"
           pr-test-filename: testdriver-results.yaml
           prerun: |
-            echo "TD_SSH_SETUP_SCRIPT: $TD_SSH_SETUP_SCRIPT"
+            printenv
           prompt: |
             1. check that Visual Studio Code is visible with the cdc_fifo folder open
 

--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -43,9 +43,9 @@ jobs:
           key: ${{ secrets.TESTDRIVER_API_KEY }}
           os: linux
           prerun: |
-            echo "# Asserting all values are empty in testdriverai/action's prerun"
-            if [[ -n "$SOME_SECRET" ]]; then echo "SOME_SECRET should be empty"; exit 1; fi
-            if [[ -n "$TD_SOME_SECRET" ]]; then echo "TD_SOME_SECRET should be empty"; exit 1; fi
+            Write-Host "# Asserting all values are empty in testdriverai/action's prerun"
+            if ($env:SOME_SECRET) { Write-Host "SOME_SECRET should be empty"; exit 1 }
+            if ($env:TD_SOME_SECRET) { Write-Host "TD_SOME_SECRET should be empty"; exit 1 }
           prompt: |
             Page should contain "TestDriver.ai Sandbox"
         env:

--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -26,27 +26,22 @@ jobs:
       - uses: actions/checkout@v4
       - name: Re-export secrets to environment
         run: |
-          echo ${TD_API_KEY} > key
-          echo "TD_API_KEY_2=$(cat key)" >> $GITHUB_ENV
+          echo "SOME_SECRET_2=${SOME_SECRET}" >> $GITHUB_ENV
 
       - name: Run TestDriver
         id: testdriver
         uses: testdriverai/action@main
         with:
-          key: ${{ env.TD_API_KEY }}
+          key: ${{ secrets.TD_API_KEY }}
           os: linux
           prerun: |
             echo "SOME_SECRET: $SOME_SECRET"
+            echo "SOME_SECRET_2: $SOME_SECRET_2"
+            echo "SOME_SCRIPT: $SOME_SCRIPT"
           prompt: |
-            1. check that Visual Studio Code is visible with the cdc_fifo folder open
-
+            Page should contain "TestDriver.ai Sandbox"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TD_VM: true
-          TD_VM_RESOLUTION: 1280x1024
-          TD_OVERLAY: true
-          TD_ANALYTICS: false
-          FORCE_COLOR: "3"
-          TD_API_KEY: ${{ env.TD_API_KEY }}
-          TD_SSH_SETUP_SCRIPT: ${{ env.TD_SSH_SETUP_SCRIPT }}
-          TD_SSH_KEY: ${{ env.TD_SSH_KEY }}
+          SOME_SECRET: ${{ env.SOME_SECRET }}
+          SOME_SCRIPT: ${{ env.SOME_SCRIPT }}
+          TD_WEBSITE: "https://testdriver-sandbox.vercel.app"

--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -43,11 +43,11 @@ jobs:
           key: ${{ secrets.TESTDRIVER_API_KEY }}
           os: linux
           prerun: |
-            Write-Host "# Asserting all values are empty in testdriverai/action's prerun"
+            Write-Host "# Asserting values in testdriverai/action's prerun"
             Write-Host "SOME_SECRET actual value: '$($env:SOME_SECRET)'"
-            if ($env:SOME_SECRET) { Write-Host "SOME_SECRET should be empty"; }
+            if ($env:SOME_SECRET) { Write-Host "SOME_SECRET should be empty"; exit 1 }
             Write-Host "TD_SOME_SECRET actual value: '$($env:TD_SOME_SECRET)'"
-            if ($env:TD_SOME_SECRET) { Write-Host "TD_SOME_SECRET should be empty"; }
+            if ($env:TD_SOME_SECRET -ne "secrets.SOME_SECRET") { Write-Host "TD_SOME_SECRET should be 'secrets.SOME_SECRET'"; exit 1 }
           prompt: |
             Page should contain "TestDriver.ai Sandbox"
         env:

--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -44,8 +44,10 @@ jobs:
           os: linux
           prerun: |
             Write-Host "# Asserting all values are empty in testdriverai/action's prerun"
-            if ($env:SOME_SECRET) { Write-Host "SOME_SECRET should be empty"; exit 1 }
-            if ($env:TD_SOME_SECRET) { Write-Host "TD_SOME_SECRET should be empty"; exit 1 }
+            Write-Host "SOME_SECRET actual value: '$($env:SOME_SECRET)'"
+            if ($env:SOME_SECRET) { Write-Host "SOME_SECRET should be empty"; }
+            Write-Host "TD_SOME_SECRET actual value: '$($env:TD_SOME_SECRET)'"
+            if ($env:TD_SOME_SECRET) { Write-Host "TD_SOME_SECRET should be empty"; }
           prompt: |
             Page should contain "TestDriver.ai Sandbox"
         env:

--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -36,7 +36,7 @@ jobs:
           key: ${{ env.TD_API_KEY }}
           os: linux
           prerun: |
-            printenv
+            echo "SOME_SECRET: $SOME_SECRET"
           prompt: |
             1. check that Visual Studio Code is visible with the cdc_fifo folder open
 

--- a/.github/workflows/test-env-passthrough.yaml
+++ b/.github/workflows/test-env-passthrough.yaml
@@ -34,9 +34,9 @@ jobs:
           key: ${{ secrets.TESTDRIVER_API_KEY }}
           os: linux
           prerun: |
-            echo "SOME_SECRET: $SOME_SECRET"
-            echo "SOME_SECRET_2: $SOME_SECRET_2"
-            echo "SOME_SCRIPT: $SOME_SCRIPT"
+            echo "SOME_SECRET: ${SOME_SECRET}"
+            echo "SOME_SECRET_2: ${SOME_SECRET_2}"
+            echo "SOME_SCRIPT: ${SOME_SCRIPT}"
           prompt: |
             Page should contain "TestDriver.ai Sandbox"
         env:

--- a/testdriver/lifecycle/prerun.yaml
+++ b/testdriver/lifecycle/prerun.yaml
@@ -1,6 +1,15 @@
 version: 5.1.1
 session: 67f00511acbd9ccac373edf7
 steps:
+  - prompt: print environment variables
+    commands:
+      - command: exec
+        lang: shell
+        linux: |
+          printf '%s\n' "${SOME_SECRET}"
+          printf '%s\n' "${SOME_SECRET_2}"
+          printf '%s\n' "${SOME_SCRIPT}"
+        mac: |
   - prompt: launch chrome
     commands:
       - command: exec

--- a/testdriver/lifecycle/prerun.yaml
+++ b/testdriver/lifecycle/prerun.yaml
@@ -6,9 +6,11 @@ steps:
       - command: exec
         lang: shell
         linux: |
-          printf '%s\n' "${SOME_SECRET}"
-          printf '%s\n' "${SOME_SECRET_2}"
-          printf '%s\n' "${SOME_SCRIPT}"
+          printf 'SOME_SECRET:%s\n' "${SOME_SECRET}"
+          printf 'SOME_SECRET_2:%s\n' "${SOME_SECRET_2}"
+          printf 'SOME_SCRIPT:%s\n' "${SOME_SCRIPT}"
+          printf 'TD_SOME_SECRET:%s\n' "${TD_SOME_SECRET}"
+          printf 'TD_SOME_SCRIPT:%s\n' "${TD_SOME_SCRIPT}"
   - prompt: launch chrome
     commands:
       - command: exec

--- a/testdriver/lifecycle/prerun.yaml
+++ b/testdriver/lifecycle/prerun.yaml
@@ -6,9 +6,17 @@ steps:
       - command: exec
         lang: shell
         linux: |
-          [ -z "$SOME_SECRET" ] || { echo "SOME_SECRET should be empty"; exit 1; }
-          [ "$TD_SOME_SECRET" = "secrets.SOME_SECRET" ] || { echo "TD_SOME_SECRET should be 'secrets.SOME_SECRET' but is $TD_SOME_SECRET"; exit 1; }
+          # Assert SOME_SECRET is empty
+          if [ ! -z "$SOME_SECRET" ]; then
+            echo "SOME_SECRET should be empty but was '$SOME_SECRET'"
+            exit 1
+          fi
 
+          # Assert TD_SOME_SECRET has correct value  
+          if [ "$TD_SOME_SECRET" != "secrets.SOME_SECRET" ]; then
+            echo "TD_SOME_SECRET should be 'secrets.SOME_SECRET' but was '$TD_SOME_SECRET'"
+            exit 1
+          fi
   # Normal test behavior now...
   - prompt: launch chrome
     commands:

--- a/testdriver/lifecycle/prerun.yaml
+++ b/testdriver/lifecycle/prerun.yaml
@@ -1,15 +1,15 @@
 version: 5.1.1
 session: 67f00511acbd9ccac373edf7
 steps:
-  - prompt: print environment variables
+  - prompt: Only TD_* values should be available to TestDriver
     commands:
       - command: exec
         lang: shell
         linux: |
-          printf 'SOME_SECRET:%s\n' "$SOME_SECRET"
-          printf 'SOME_SCRIPT:%s\n' "$SOME_SCRIPT"
-          printf 'TD_SOME_SECRET:%s\n' "$TD_SOME_SECRET"
-          printf 'TD_SOME_SCRIPT:%s\n' "$TD_SOME_SCRIPT"
+          [ -z "$SOME_SECRET" ] || { echo "SOME_SECRET should be empty"; exit 1; }
+          [ "$TD_SOME_SECRET" = "secrets.SOME_SECRET" ] || { echo "TD_SOME_SECRET should be 'secrets.SOME_SECRET' but is $TD_SOME_SECRET"; exit 1; }
+
+  # Normal test behavior now...
   - prompt: launch chrome
     commands:
       - command: exec

--- a/testdriver/lifecycle/prerun.yaml
+++ b/testdriver/lifecycle/prerun.yaml
@@ -9,7 +9,6 @@ steps:
           printf '%s\n' "${SOME_SECRET}"
           printf '%s\n' "${SOME_SECRET_2}"
           printf '%s\n' "${SOME_SCRIPT}"
-        mac: |
   - prompt: launch chrome
     commands:
       - command: exec

--- a/testdriver/lifecycle/prerun.yaml
+++ b/testdriver/lifecycle/prerun.yaml
@@ -6,11 +6,10 @@ steps:
       - command: exec
         lang: shell
         linux: |
-          printf 'SOME_SECRET:%s\n' "${SOME_SECRET}"
-          printf 'SOME_SECRET_2:%s\n' "${SOME_SECRET_2}"
-          printf 'SOME_SCRIPT:%s\n' "${SOME_SCRIPT}"
-          printf 'TD_SOME_SECRET:%s\n' "${TD_SOME_SECRET}"
-          printf 'TD_SOME_SCRIPT:%s\n' "${TD_SOME_SCRIPT}"
+          printf 'SOME_SECRET:%s\n' "$SOME_SECRET"
+          printf 'SOME_SCRIPT:%s\n' "$SOME_SCRIPT"
+          printf 'TD_SOME_SECRET:%s\n' "$TD_SOME_SECRET"
+          printf 'TD_SOME_SCRIPT:%s\n' "$TD_SOME_SCRIPT"
   - prompt: launch chrome
     commands:
       - command: exec

--- a/testdriver/lifecycle/prerun.yaml
+++ b/testdriver/lifecycle/prerun.yaml
@@ -9,13 +9,16 @@ steps:
           # Assert SOME_SECRET is empty
           if [ ! -z "$SOME_SECRET" ]; then
             echo "SOME_SECRET should be empty but was '$SOME_SECRET'"
-            exit 1
           fi
 
-          # Assert TD_SOME_SECRET has correct value  
+          # Assert TD_SOME_SECRET has correct value when using $ 
           if [ "$TD_SOME_SECRET" != "secrets.SOME_SECRET" ]; then
             echo "TD_SOME_SECRET should be 'secrets.SOME_SECRET' but was '$TD_SOME_SECRET'"
-            exit 1
+          fi
+
+          # Assert TD_SOME_SECRET has correct value when using curly braces
+          if [ "${TD_SOME_SECRET}" != "secrets.SOME_SECRET" ]; then
+            echo "TD_SOME_SECRET should be 'secrets.SOME_SECRET' but was '$TD_SOME_SECRET'"
           fi
   # Normal test behavior now...
   - prompt: launch chrome


### PR DESCRIPTION
> https://www.notion.so/prerun-doesn-t-add-TD_-variables-to-env-only-interpolates-them-21c6adb97c8881a38f39fa4012b60d1e?source=copy_link

The confusing 🐞 is that https://github.com/testdriverai/action/blob/08b043cc059ed00f0b92ed488e1d382c11edbcff/src/index.js#L32-L41 extracts variables for interpolation in strings (https://github.com/testdriverai/action/blob/08b043cc059ed00f0b92ed488e1d382c11edbcff/src/index.js#L138), but **not for setting in the environment**.

See [Example 2](https://docs.testdriver.ai/guide/environment-variables#example-2) in the docs:
> Be sure to expand these in your test with `${TD_TEST_USERNAME}` and `${TD_TEST_PASSWORD}` notation!


# Demo

See: https://app.testdriver.ai/replay/685ad0a7d681a12d451b24ab?share=w9LRx6vfwiH3Zq8XKh5FQ

## `testdriverai/action`'s `prerun`

```console
TestDriver: Running Prerun Script
```
Write-Host "# Asserting values in testdriverai/action's prerun"
Write-Host "SOME_SECRET actual value: '$($env:SOME_SECRET)'"
if ($env:SOME_SECRET) { Write-Host "SOME_SECRET should be empty"; exit 1 }
Write-Host "TD_SOME_SECRET actual value: '$($env:TD_SOME_SECRET)'"
if ($env:TD_SOME_SECRET -ne "secrets.SOME_SECRET") { Write-Host "TD_SOME_SECRET should be 'secrets.SOME_SECRET'"; exit 1 }
```
From: "C:\Users\TESTDR~1\AppData\Local\Temp\prerun.ps1"
# Asserting values in testdriverai/action's prerun
SOME_SECRET actual value: ''
TD_SOME_SECRET actual value: 'secrets.SOME_SECRET'
```

## `testdriver/lifecycle/prerun.yaml`

### Using `$`

```console
sending value of `linux` to vm...
{
 type: 'error',
 error: {
 name: 'CommandExitError',
 result: {
 exitCode: 1,
 error: 'exit status 1',
 stdout: "TD_SOME_SECRET should be 'secrets.SOME_SECRET' but was ''\n",
 stderr: ''
 }
 },
 requestId: 'ftc9jg1750781247418'
}
```

### Using `${...}`

```console
runner\_work\testdriver\testdriver\testdriver\lifecycle\prerun.yaml...
> Only TD_* values should be available to TestDriver
command='exec' lang='shell' linux='# Assert SOME_SECRET is empty
if [ ! -z "$SOME_SECRET" ]; then
 echo "SOME_SECRET should be empty but was '$SOME_SECRET'"
fi
# Assert TD_SOME_SECRET has correct value when using $
if [ "$TD_SOME_SECRET" != "****" ]; then
 echo "TD_SOME_SECRET should be '****' but was '$TD_SOME_SECRET'"
fi
# Assert TD_SOME_SECRET has correct value when using curly braces
if [ "****" != "****" ]; then
 echo "TD_SOME_SECRET should be '****' but was '$TD_SOME_SECRET'"
fi
'
```