### PR TITLE
TD-1924 – Add test for +→

### DIFF
--- a/testdriver/press-keys.yaml
+++ b/testdriver/press-keys.yaml
@@ -15,3 +15,7 @@ steps:
           - t
       - command: assert
         expect: a new tab was created
+      - command: press-keys
+        keys:
+          - command
+          - right


### PR DESCRIPTION
https://www.notion.so/can-t-do-win-right-arrow-multiple-non-modifier-keys-error-v5-7-7-2056adb97c8880adb1c9ccc3f5127961?source=copy_link