### PR TITLE
TD-2179: fix mutliple modifier keys (local)

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -505,26 +505,13 @@ let commands = {
         true,
       );
 
-      modsToPress.forEach((key) => {
-        robot.keyToggle(key, "down");
-      });
-
+      // Use the simple robotjs pattern: robot.keyTap('i', ['command', 'alt']);
       robot.keyTap(keysPressed[0], modsToPress);
     } else {
       await sandbox.send({ type: "press", keys: keysPressed });
     }
 
-    // finally, press the keys
-
     await redraw.wait(5000);
-
-    // keyTap will release the normal keys, but will not release modifier keys
-    // so we need to release the modifier keys manually
-    if (!config.TD_VM) {
-      modsToPress.forEach((key) => {
-        robot.keyToggle(key, "up");
-      });
-    }
 
     return;
   },


### PR DESCRIPTION
This fixes issues of unable to press shortcuts that involves multiple [modifier keys](https://learn.microsoft.com/en-us/dotnet/api/system.windows.input.modifierkeys?view=windowsdesktop-9.0)

So the fix was basically replacing robotjs `keyToggle` with `keyTap` and passing in the modifier keys as the array (second argument) as there's some weird issue at robotjs end, like we cannot do this 
```js
robot.keyToggle(command, "down");
robot.keyToggle(alt, "down");
robot.keyTap(i)
robot.keyToggle(command, "up");
robot.keyToggle(alt, "up");
```
but instead need to do this ` robot.keyTap('i', ['command', 'alt']);` 

I am also unsure as to why it wasn't done this way initially, but I am guessing some other issue at their end prevented it. 
anyways, [here's](https://www.loom.com/share/5069d46e4a13431e848e101879a2c70c?sid=947f2c20-7cf7-4861-aa58-770a76eee530) the loom of this working. 

@ericclemmons also has another PR https://github.com/testdriverai/testdriverai/pull/298 
which i believe if my understanding is correct, its considering "right arrow" as a modifier key, in that case this PR fixes that. 