### PR TITLE
TD-2201 fix /run without file path

### DIFF
--- a/agent.js
+++ b/agent.js
@@ -854,7 +854,7 @@ const firstPrompt = async () => {
     } else if (input.indexOf("/manual") == 0) {
       await manualInput(commands.slice(1).join(" "));
     } else if (input.indexOf("/run") == 0) {
-      let file = commands[1];
+      const file = commands[1];
       if (file) thisFile = file;
       const flags = commands.slice(2);
       let shouldSave = flags.includes("--save") ? true : false;

--- a/agent.js
+++ b/agent.js
@@ -855,7 +855,6 @@ const firstPrompt = async () => {
       await manualInput(commands.slice(1).join(" "));
     } else if (input.indexOf("/run") == 0) {
       const file = commands[1];
-      if (file) thisFile = file;
       const flags = commands.slice(2);
       let shouldSave = flags.includes("--save") ? true : false;
       let shouldExit = flags.includes("--exit") ? true : false;

--- a/agent.js
+++ b/agent.js
@@ -854,8 +854,8 @@ const firstPrompt = async () => {
     } else if (input.indexOf("/manual") == 0) {
       await manualInput(commands.slice(1).join(" "));
     } else if (input.indexOf("/run") == 0) {
-      const file = commands[1];
-      thisFile = file;
+      let file = commands[1];
+      if (file) thisFile = file;
       const flags = commands.slice(2);
       let shouldSave = flags.includes("--save") ? true : false;
       let shouldExit = flags.includes("--exit") ? true : false;


### PR DESCRIPTION
Fix is simple, `thisFile` has the initial file path or basically the second argument https://github.com/testdriverai/testdriverai/blob/3f5f3f84eb9496120ea1891405aac2748de46d62/agent.js#L1245

Hence we update it only if the `file` is provided, i.e, again the second argument during `/run` 

[here's](https://www.loom.com/share/10db36c2181f4197b31cc828b8d739b7?sid=1ec2a8c1-c8cc-4040-9582-73d48d8d6898) the loom of its working