### PR TITLE
Tarun/fix modifier keys combo

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -506,8 +506,8 @@ let commands = {
       );
 
       // Use the simple robotjs pattern: robot.keyTap('i', ['command', 'alt']);
-       robot.keyTap(keysPressed[0], modsToPress);
-       robot.keyToggle(keysPressed[0], "up");
+      robot.keyTap(keysPressed[0], modsToPress);
+      robot.keyToggle(keysPressed[0], "up");
     } else {
       await sandbox.send({ type: "press", keys: keysPressed });
     }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -506,7 +506,8 @@ let commands = {
       );
 
       // Use the simple robotjs pattern: robot.keyTap('i', ['command', 'alt']);
-      robot.keyTap(keysPressed[0], modsToPress);
+       robot.keyTap(keysPressed[0], modsToPress);
+       robot.keyToggle(keysPressed[0], "up");
     } else {
       await sandbox.send({ type: "press", keys: keysPressed });
     }

--- a/testdriver/press-keys.yaml
+++ b/testdriver/press-keys.yaml
@@ -13,7 +13,7 @@ steps:
         keys:
           - command
           - t
-      - command: wait-for-text
+       - command: wait-for-text
         text: "Learn more"
       - command: press-keys
         keys:
@@ -22,3 +22,14 @@ steps:
           - i
       - command: wait-for-text
         text: "Elements"
+      - command: press-keys
+        keys:
+          - command
+          - t
+      - command: type
+        text: google.com
+      - command: press-keys
+        keys:
+          - enter
+      - command: assert
+        expect: google appears

--- a/testdriver/press-keys.yaml
+++ b/testdriver/press-keys.yaml
@@ -13,7 +13,7 @@ steps:
         keys:
           - command
           - t
-       - command: wait-for-text
+      - command: wait-for-text
         text: "Learn more"
       - command: press-keys
         keys:


### PR DESCRIPTION
@ericclemmons after https://github.com/testdriverai/testdriverai/pull/299 , where we changed the way it would press modifier keys, its kinda getting stuck, like when it needs to type something after pressing keys, it messes up or just kinda execute the same `press-keys` sequence again, hence we need to release the keys. 

[Here's](https://www.loom.com/share/602e314b32ab477aa74e8a73c9434727?sid=1bbb0859-f708-489a-96f1-dbab87885148) the loom showing the current behavior and fixed behavior.

I have also updated the tests to catch something like this.