### PR TITLE
TD-2221 Feat: Add support to windows key

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -471,6 +471,9 @@ let commands = {
       if (key === "command" || key === "control") {
         key = commandOrControl;
       }
+      if (key === "win") {
+        key = "command";
+      }
 
       if (!config.TD_VM && modifierKeys.includes(key)) {
         modifierKeysPressed.push(key);

--- a/lib/keymaps/robot.js
+++ b/lib/keymaps/robot.js
@@ -41,6 +41,7 @@ module.exports = module.exports = {
   f24: "f24",
   capslock: "capslock",
   command: "command",
+  win: "win",
   alt: "alt",
   right_alt: "right_alt",
   control: "control",


### PR DESCRIPTION
So this PR adds the feat of pressing windows key.
This was one of those cases where code written is inversely proportional to time spent.

We can't just map command to command, as it would almost destroy cross-os compatibility of the tests.
example if the test has something like 
```yaml
- command: press-keys
       keys: 
          - command
          - f
 # search for some text
 ```
 In mac this would search but in wind it would actually do windows + f which is kinda bad ( on my machine it opens some feedback app )
 And importantly, we need the yaml to upload the **spirit of the test** 
 
 Hence, we used win key, thanks to @misterludden for the idea, because win is mapped to command eventually, the test still works fine on mac as well.
 A gotcha being, if u see `win` in the yaml it should be understood that the test was written mainly for windows.
 That said, we can have like a enum where we define a list say separated by `/` or `||` and picks up the one based on the `os.platflorm()`. Haven't seen a scenario yet for this so maybe add it to the timebox.
 
 Anyways, [here's](https://www.loom.com/share/d0dd7806a3284f45b4bb7f947fcd2d26?sid=2a3e59b0-3768-4687-9cea-f736bc688957) the recording of it working on my local windows, ignore not being able to press enter, [it doesn't work on my machine](https://testdriverai.slack.com/archives/C02AUTY0WQ5/p1751555385380209) haha

Needs this [PR](https://github.com/replayableio/api/pull/290) to let the AI generate the command. 
currently if I ask "press windows key + r" it generates "command + r" , that will fixed with this ^