### PR TITLE
Make spawn-runner.sh executable in workflow

### DIFF
--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Setup AWS Instance
         id: aws-setup
         run: |
+          chmod +x ./setup/aws/spawn-runner.sh
           OUTPUT=$(./setup/aws/spawn-runner.sh | tee /dev/stderr) # Capture and display output
           echo "$OUTPUT"
           PUBLIC_IP=$(echo "$OUTPUT" | grep "PUBLIC_IP=" | cut -d'=' -f2)


### PR DESCRIPTION
`/home/runner/work/_temp/e8115f1f-cc92-40b2-b16f-8c3bf618a076.sh: line 1: ./setup/aws/spawn-runner.sh: Permission denied`

We get this error, by default, the scripts are not executable ig