### PR TITLE
Fix: Timing precision issue while computing timeout

### DIFF
--- a/agent/lib/redraw.js
+++ b/agent/lib/redraw.js
@@ -153,7 +153,7 @@ const createRedraw = (emitter, system, sandbox) => {
     let nowImage = await system.captureScreenPNG(0.25, true);
     let timeElapsed = Date.now() - startTime;
     let diffPercent = 0;
-    let isTimeout = timeElapsed > timeoutMs - 0.5;
+    let isTimeout = timeElapsed > timeoutMs - 0.25;
 
     if (!screenHasRedrawn) {
       diffPercent = await imageDiffPercent(startImage, nowImage);


### PR DESCRIPTION
There's a precision gap between the interval from start to now and the `timeout` parameter, almost a order of 0.07ms.

[2025-11-20T14:30:28.783Z] [command:progress] 
{"command":"wait","status":"completed",**"timing":4999.93002499998**,"data":
{"command":"wait",**"timeout":5000**},"depth":1,"timestamp":1763649028783}


Hence added a delta of 0.25ms (just to be extra safe) cuz we also need to account for cases where it goes overboard, I have seen something like `5000.8223`  